### PR TITLE
Add system info tool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/source/info-tool/ev3dev-system-info.sh
+++ b/source/info-tool/ev3dev-system-info.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+if [ "$1" == '--help' ]; then
+  echo "ev3dev system info tool. Prints common platform information for use in reporting issues."
+  exit
+fi
+
+get_colon_separated_file_prop () {
+  target_line=$(grep -m1 ^"$2" "$1")
+  echo "${target_line##*: }"
+}
+
+get_package_version () {
+  target_line=$(dpkg-query -s "$1" | grep -m1 ^Version)
+  echo "${target_line##*: }"
+}
+
+# dpkg-query --status doesn't accept wildcards, but --list does...
+get_package_version_with_wildcard () {
+  echo $(dpkg-query -l "$1" | grep "$1" | awk '{print $3}')
+}
+
+print_val() {
+  printf "%-20s%s\n" "$1: " "$2"
+}
+
+print_val "Kernel version" "$(uname -r)"
+
+if [ -f /proc/device-tree/model ]; then
+  print_val "Board" "$(cat /proc/device-tree/model)"
+else
+  print_val "Board" "$(get_colon_separated_file_prop /proc/cpuinfo 'Hardware')"
+fi
+
+print_val "Revision" "$(get_colon_separated_file_prop /proc/cpuinfo 'Revision')"
+print_val "Brickman" "$(get_package_version brickman)"
+print_val "ev3devKit" "$(get_package_version_with_wildcard ev3devkit-\*)"


### PR DESCRIPTION
This is the result of ev3dev/ev3dev#483.

I have included a simple shell script that prints the information that was listed in the above issue. I don't do much bash programming, so I'm sure that there are better ways to do some of this -- I'm happy to make modifications and take feedback. I'm mainly trying to get the initial version of this script out there so that you can take a look and make sure I'm on the right track. The fact that the `libev3devkit` package includes the version number made it a bit tougher (because you need to know the whole package name to pass to `dpkg-query -s`), but I got around that. I put all the information querying functionality into separate functions so that it is easy to add new info items in the future.

Questions:
- Should it have any command-line options? It didn't seem like there were any functional options that would be needed, but a `--help` option might make sense. Or maybe (if there is more complex information that we want to add) an option to format the output as markdown... but I think that's probably over-doing it.
- Can I get a sample of the contents of `/proc/device-tree/model`? I have a RasPI, but not either of the EV3-themed accessories, so I don't actually know what that file should contain.
- I used separate functions for package versions with(out) wildcards. Should I just use the version that accepts wildcards for all package lookups?
